### PR TITLE
E7: rename RentersPoints to RenterPoints to match previous function name

### DIFF
--- a/slides/slides.md
+++ b/slides/slides.md
@@ -227,7 +227,7 @@ other control structures with several responsibilities in the body.
 - Holding a `std::vector<Rental>` and `customerName`
 - The `RentalRecord` class should get the following methods:
     - `getTotalAmount()`
-    - `getFrequentRentersPoints()`
+    - `getFrequentRenterPoints()`
     - `getCustomerName()`
 
 - Presentation logic (everthing accessing `in` or `out`) must be kept in `run` for now


### PR DESCRIPTION
Hi,
I noticed a tiny mismatch between E6 and E2/E5 in the function name for the Renter points calculation. In case this wasn't intentional, this PR fixes this.